### PR TITLE
fix imdb online search box listing url 's

### DIFF
--- a/trace.php
+++ b/trace.php
@@ -296,9 +296,6 @@ function fixup_HTML($html)
 
         // imdb form does not accept utf8
         $html = preg_replace("/(form\s+.*?)(>)/i", '\\1 accept-charset="ISO-8859-1" \\2', $html );
-    
-        // javascript replacement to allow selection on search dropdown screens to work
-        $html = replace_javascript ($html);        
     }  
  
     return $html;
@@ -368,139 +365,71 @@ function request($urlonly=false)
 	return $page;
 }
 
-function replace_javascript($html)
+function fixup_javascript($html)
 {
+    global $uri;
+    
+    if (stristr($uri['host'], 'imdb') === false)
+    {
+        return $html;
+    }
     $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/(.*?)-(.*?)js#'; 
     preg_match_all($pattern,$html, $matches_all);
     echo "<br> test for switch - ";
     var_dump($matches_all);  
     var_dump($matches_all[1]);
     $x = 0;
-    foreach ($matches_all[1] as $value)
+    foreach ($matches_all[1] as $js_page_type)
     {
-       echo "<br> in for each loop - ".$value;
-         switch ($value)
+        echo "<br> in for each loop - ".$js_page_type;
+         switch ($js_page_type)
         {
             case "pagelayout":
-                $js_file = file_get_contents($matches_all[0][$x]);
-                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
-                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - ";
-                    var_dump($matches);
-                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
-                $js_file = preg_replace($pattern,$replacement,$js_file);
-                // <a class="moreResults" href="
-                $pattern = '#<a class=\"moreResults\" href=\"#';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - 2nd find - ";
-                    var_dump($matches);
-                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
-                $js_file = preg_replace($pattern,$replacement,$js_file);
-                // save file to cache    
-                $tempfolder = cache_get_folder('');
-                $file_path = './'.$tempfolder.'imdb-clone-pagelayout.js';
-                file_put_contents($file_path, $js_file);
-                // https://m.media-amazon.com/images/G/01/imdb/js/collections/pagelayout-217123936._CB476660927_.js 
-                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/pagelayout-(.*?)js#';
-                if (preg_match($pattern, $html, $matches))
-                {        
-                    $replacement = $file_path;
-                    $html = preg_replace($pattern,$replacement,$html);
-                }
-                break;
-
             case "title":
-                $js_file = file_get_contents($matches_all[0][$x]);
-                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
-                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - ";
-                    var_dump($matches);
-                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
-                $js_file = preg_replace($pattern,$replacement,$js_file);
-                // <a class="moreResults" href="
-                $pattern = '#<a class=\"moreResults\" href=\"#';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - 2nd find - ";
-                    var_dump($matches);
-                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
-                $js_file = preg_replace($pattern,$replacement,$js_file);                
-                // save file to cache    
-                $tempfolder = cache_get_folder('');
-                $file_path = './'.$tempfolder.'imdb-clone-title.js';
-                file_put_contents($file_path, $js_file);
-                // https://m.media-amazon.com/images/G/01/imdb/js/collections/title-3922816103._CB476927104_.js
-                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/title-(.*?)js#';
-                if (preg_match($pattern, $html, $matches))
-                {        
-                    $replacement = $file_path;
-                    $html = preg_replace($pattern,$replacement,$html);
-                }                   
-                break;
-
             case "name":
-                $js_file = file_get_contents($matches_all[0][$x]);
-                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
-                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - ";
-                    var_dump($matches);
-                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
-                $js_file = preg_replace($pattern,$replacement,$js_file);
-                // <a class="moreResults" href="
-                $pattern = '#<a class=\"moreResults\" href=\"#';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - 2nd find - ";
-                    var_dump($matches);
-                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
-                $js_file = preg_replace($pattern,$replacement,$js_file);                
-                // save file to cache    
-                $tempfolder = cache_get_folder('');
-                $file_path = './'.$tempfolder.'imdb-clone-name.js';
-                file_put_contents($file_path, $js_file);
-                // https://m.media-amazon.com/images/G/01/imdb/js/collections/name-3353207162._CB476927128_.js
-                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/name-(.*?)js#';
-                if (preg_match($pattern, $html, $matches))
-                {        
-                    $replacement = $file_path;
-                    $html = preg_replace($pattern,$replacement,$html);
-                }
-                break;
-                
             case "consumersite";
-                // yet te build
-               $js_file = file_get_contents($matches_all[0][$x]);
-                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
-                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - ";
-                    var_dump($matches);
-                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
-                $js_file = preg_replace($pattern,$replacement,$js_file);
-                // <a class="moreResults" href="
-                $pattern = '#<a class=\"moreResults\" href=\"#';
-                preg_match($pattern, $js_file, $matches);
-                echo "<br> js file - 2nd find - ";
-                    var_dump($matches);
-                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
-                $js_file = preg_replace($pattern,$replacement,$js_file);                
-                // save file to cache    
-                $tempfolder = cache_get_folder('');
-                $file_path = './'.$tempfolder.'imdb-clone-consumersite.js';
-                file_put_contents($file_path, $js_file);
-                // https://m.media-amazon.com/images/G/01/imdb/js/collections/consumersite-1849299544._CB476612758_.js
-                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/consumersite-(.*?)js#';
-                if (preg_match($pattern, $html, $matches))
-                {        
-                    $replacement = $file_path;
-                    $html = preg_replace($pattern,$replacement,$html);
-                }                
+                $html = replace_javascript ($html,$js_page_type,$matches_all[0][$x]);
                 break;
         }
         $x++ ;
     }
     return ($html);
+}
+
+function replace_javascript ($html, $js_page_type, $js_file_name)
+{
+    // get contents of javascript file
+    $js_file_data = file_get_contents($js_file_name);
+    // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
+    $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
+    preg_match($pattern, $js_file_data, $matches);
+    echo "<br> js file - ";
+    var_dump($matches);
+    $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
+    $js_file_data = preg_replace($pattern,$replacement,$js_file_data);
+    
+    // <a class="moreResults" href="
+    $pattern = '#<a class=\"moreResults\" href=\"#';
+    preg_match($pattern, $js_file_data, $matches);
+    echo "<br> js file - 2nd find - ";
+        var_dump($matches);
+    $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
+    $js_file_data = preg_replace($pattern,$replacement,$js_file_data);
+    
+    // save file to cache    
+    $tempfolder = cache_get_folder('');
+    $file_path = './'.$tempfolder.'imdb-clone-'.$js_page_type.'.js';
+    file_put_contents($file_path, $js_file_data);
+    // https://m.media-amazon.com/images/G/01/imdb/js/collections/pagelayout-217123936._CB476660927_.js 
+ ////   $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/pagelayout-(.*?)js#';
+    $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/'.$js_page_type.'-(.*?)js#';
+    echo "<BR> - pattern- $pattern";
+    if (preg_match($pattern, $html, $matches))
+    {        
+        $replacement = $file_path;
+        $html = preg_replace($pattern,$replacement,$html);
+    }    
+    return $html;
 }
 
 // make sure this is a local access
@@ -534,6 +463,7 @@ else
 
 	// convert HTML for output
 	$page = fixup_HTML($page);
+    $page = fixup_javascript($page);
 }
 
 if ($iframe == 2) 

--- a/trace.php
+++ b/trace.php
@@ -288,17 +288,20 @@ function fixup_HTML($html)
 	// href
 	$html = preg_replace_callback("/(<a\s+[^>]*?href\s*=\s*(\"|'))([^>]*?)(\\2[^>]*?>)(.*?)(<\/a\s*>)/is", '_replace_enclosed_tag_traced', $html);
 	$html = preg_replace_callback("/(<a\s+[^>]*?href\s*=\s*())([\d\w\.\/\+\%-:=&_]+)(\s*[^>]*?>)(.*?)(<\/a\s*>)/is", '_replace_enclosed_tag_traced', $html);
-
+                     
 	// title
     if (stristr($uri['host'], 'imdb'))
     {
-		$html = preg_replace_callback("/(<h1>)(.*?)(<span>)/si", 'imdb_replace_title_callback', $html);
+	$html = preg_replace_callback("/(<h1>)(.*?)(<span>)/si", 'imdb_replace_title_callback', $html);
 
         // imdb form does not accept utf8
         $html = preg_replace("/(form\s+.*?)(>)/i", '\\1 accept-charset="ISO-8859-1" \\2', $html );
-	} 
-
-	return $html;
+    
+        // javascript replacement to allow selection on search dropdown screens to work
+        $html = replace_javascript ($html);        
+    }  
+ 
+    return $html;
 }
 
 function request($urlonly=false)
@@ -363,6 +366,141 @@ function request($urlonly=false)
 		$page = $response['data'];
 	}
 	return $page;
+}
+
+function replace_javascript($html)
+{
+    $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/(.*?)-(.*?)js#'; 
+    preg_match_all($pattern,$html, $matches_all);
+    echo "<br> test for switch - ";
+    var_dump($matches_all);  
+    var_dump($matches_all[1]);
+    $x = 0;
+    foreach ($matches_all[1] as $value)
+    {
+       echo "<br> in for each loop - ".$value;
+         switch ($value)
+        {
+            case "pagelayout":
+                $js_file = file_get_contents($matches_all[0][$x]);
+                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
+                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - ";
+                    var_dump($matches);
+                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
+                $js_file = preg_replace($pattern,$replacement,$js_file);
+                // <a class="moreResults" href="
+                $pattern = '#<a class=\"moreResults\" href=\"#';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - 2nd find - ";
+                    var_dump($matches);
+                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
+                $js_file = preg_replace($pattern,$replacement,$js_file);
+                // save file to cache    
+                $tempfolder = cache_get_folder('');
+                $file_path = './'.$tempfolder.'imdb-clone-pagelayout.js';
+                file_put_contents($file_path, $js_file);
+                // https://m.media-amazon.com/images/G/01/imdb/js/collections/pagelayout-217123936._CB476660927_.js 
+                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/pagelayout-(.*?)js#';
+                if (preg_match($pattern, $html, $matches))
+                {        
+                    $replacement = $file_path;
+                    $html = preg_replace($pattern,$replacement,$html);
+                }
+                break;
+
+            case "title":
+                $js_file = file_get_contents($matches_all[0][$x]);
+                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
+                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - ";
+                    var_dump($matches);
+                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
+                $js_file = preg_replace($pattern,$replacement,$js_file);
+                // <a class="moreResults" href="
+                $pattern = '#<a class=\"moreResults\" href=\"#';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - 2nd find - ";
+                    var_dump($matches);
+                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
+                $js_file = preg_replace($pattern,$replacement,$js_file);                
+                // save file to cache    
+                $tempfolder = cache_get_folder('');
+                $file_path = './'.$tempfolder.'imdb-clone-title.js';
+                file_put_contents($file_path, $js_file);
+                // https://m.media-amazon.com/images/G/01/imdb/js/collections/title-3922816103._CB476927104_.js
+                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/title-(.*?)js#';
+                if (preg_match($pattern, $html, $matches))
+                {        
+                    $replacement = $file_path;
+                    $html = preg_replace($pattern,$replacement,$html);
+                }                   
+                break;
+
+            case "name":
+                $js_file = file_get_contents($matches_all[0][$x]);
+                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
+                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - ";
+                    var_dump($matches);
+                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
+                $js_file = preg_replace($pattern,$replacement,$js_file);
+                // <a class="moreResults" href="
+                $pattern = '#<a class=\"moreResults\" href=\"#';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - 2nd find - ";
+                    var_dump($matches);
+                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
+                $js_file = preg_replace($pattern,$replacement,$js_file);                
+                // save file to cache    
+                $tempfolder = cache_get_folder('');
+                $file_path = './'.$tempfolder.'imdb-clone-name.js';
+                file_put_contents($file_path, $js_file);
+                // https://m.media-amazon.com/images/G/01/imdb/js/collections/name-3353207162._CB476927128_.js
+                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/name-(.*?)js#';
+                if (preg_match($pattern, $html, $matches))
+                {        
+                    $replacement = $file_path;
+                    $html = preg_replace($pattern,$replacement,$html);
+                }
+                break;
+                
+            case "consumersite";
+                // yet te build
+               $js_file = file_get_contents($matches_all[0][$x]);
+                // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
+                $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - ";
+                    var_dump($matches);
+                $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
+                $js_file = preg_replace($pattern,$replacement,$js_file);
+                // <a class="moreResults" href="
+                $pattern = '#<a class=\"moreResults\" href=\"#';
+                preg_match($pattern, $js_file, $matches);
+                echo "<br> js file - 2nd find - ";
+                    var_dump($matches);
+                $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
+                $js_file = preg_replace($pattern,$replacement,$js_file);                
+                // save file to cache    
+                $tempfolder = cache_get_folder('');
+                $file_path = './'.$tempfolder.'imdb-clone-consumersite.js';
+                file_put_contents($file_path, $js_file);
+                // https://m.media-amazon.com/images/G/01/imdb/js/collections/consumersite-1849299544._CB476612758_.js
+                $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/consumersite-(.*?)js#';
+                if (preg_match($pattern, $html, $matches))
+                {        
+                    $replacement = $file_path;
+                    $html = preg_replace($pattern,$replacement,$html);
+                }                
+                break;
+        }
+        $x++ ;
+    }
+    return ($html);
 }
 
 // make sure this is a local access

--- a/trace.php
+++ b/trace.php
@@ -341,12 +341,17 @@ function request($urlonly=false)
 	if ($_POST) {
 		$post = $request;
 	} elseif ($request) {
-		$url .= "?".$request;
+            if (preg_match('/\?/',$url)) {
+                $url .= "&".$request;
+            }
+            else {
+                $url .= "?".$request;   
+            }
 	}
 
     // encode possible spaces, use %20 instead of +
 	$url = preg_replace('/ /','%20', $url);
-
+        
     $response = httpClient($url, $_GET['videodbreload'] != 'Y', array('post' => $post));
 
 	// url after redirect
@@ -373,15 +378,16 @@ function fixup_javascript($html)
     {
         return $html;
     }
+    // find all imdb javascript files
     $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/(.*?)-(.*?)js#'; 
     preg_match_all($pattern,$html, $matches_all);
-    echo "<br> test for switch - ";
-    var_dump($matches_all);  
-    var_dump($matches_all[1]);
+//    echo "<br> test for switch - ";
+//    var_dump($matches_all);  
+//    var_dump($matches_all[1]);
     $x = 0;
     foreach ($matches_all[1] as $js_page_type)
     {
-        echo "<br> in for each loop - ".$js_page_type;
+//         echo "<br> in for each loop - ".$js_page_type;
          switch ($js_page_type)
         {
             case "pagelayout":
@@ -400,19 +406,20 @@ function replace_javascript ($html, $js_page_type, $js_file_name)
 {
     // get contents of javascript file
     $js_file_data = file_get_contents($js_file_name);
+
     // var c='<a href="'+a.url+"?ref_="+b+'" class="poster"';
     $pattern = '/(var c=\'<a href=\"\'\+)(a\.url\+\"\?ref_=\"\+b\+\'\" class=\"poster"\')/';
     preg_match($pattern, $js_file_data, $matches);
-    echo "<br> js file - ";
-    var_dump($matches);
+//    echo "<br> js file - ";
+//    var_dump($matches);
     $replacement = $matches[1].'"trace.php?videodburl=http://www.imdb.com"+'.$matches[2];
     $js_file_data = preg_replace($pattern,$replacement,$js_file_data);
     
     // <a class="moreResults" href="
     $pattern = '#<a class=\"moreResults\" href=\"#';
     preg_match($pattern, $js_file_data, $matches);
-    echo "<br> js file - 2nd find - ";
-        var_dump($matches);
+//    echo "<br> js file - find moreresults";
+//    var_dump($matches);
     $replacement = $matches[0].'trace.php?videodburl=http://www.imdb.com';
     $js_file_data = preg_replace($pattern,$replacement,$js_file_data);
     
@@ -421,9 +428,8 @@ function replace_javascript ($html, $js_page_type, $js_file_name)
     $file_path = './'.$tempfolder.'imdb-clone-'.$js_page_type.'.js';
     file_put_contents($file_path, $js_file_data);
     // https://m.media-amazon.com/images/G/01/imdb/js/collections/pagelayout-217123936._CB476660927_.js 
- ////   $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/pagelayout-(.*?)js#';
     $pattern  = '#https:\/\/m.media-amazon.com\/images\/G\/01\/imdb\/js\/collections\/'.$js_page_type.'-(.*?)js#';
-    echo "<BR> - pattern- $pattern";
+//    echo "<BR> - pattern-".$pattern;
     if (preg_match($pattern, $html, $matches))
     {        
         $replacement = $file_path;


### PR DESCRIPTION
Clone imdb javascript to load correct redirect paths in imdb online tab
 - clone modified and saved to cache. ( clone refreshed every time trace is invoked).
 - add url build of $request data to use & rather than ? if ? already prenet in url  ($_get array causes two ? in url passed to imdb.)