### PR TITLE
fix borrow not working for non-numeric chars in diskid

### DIFF
--- a/borrow.php
+++ b/borrow.php
@@ -21,7 +21,7 @@ permission_or_die(PERM_WRITE, PERM_ANY);
 /**
  * input
  */
-$diskid = req_int('diskid');
+$diskid = req_string('diskid');
 $return = req_string('return');
 $who = req_string('who');
 

--- a/borrowask.php
+++ b/borrowask.php
@@ -26,7 +26,7 @@ if (empty($user))
  * input
  */
 $id = req_int('id');
-$diskid = req_int('diskid');
+$diskid = req_string('diskid');
 
 if (empty($id) || empty($diskid)) 
 {

--- a/index.php
+++ b/index.php
@@ -19,7 +19,7 @@ require_once './core/output.php';
  * input
  */
 $id = req_int('id');
-$diskid = req_int('diskid');
+$diskid = req_string('diskid');
 // start session'd settings
 $filter = req_string('filter');
 $showtv = req_int('showtv');

--- a/permissions.php
+++ b/permissions.php
@@ -29,7 +29,7 @@ function getStateOfCheckbox($name)
  * input
  */
 $id = req_int('id');
-$diskid = req_int('diskid');
+$diskid = req_string('diskid');
 $from_uid = req_int('from_uid');
 $save = req_int('save');
 $message = req_string('message');


### PR DESCRIPTION
change req_int('diskid') to req_string('diskid') as diskid is defined in DB as varchar